### PR TITLE
Default instant value set to 'true' for Board

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/deployment.dashboard.py
+++ b/contrib/kube-prometheus/assets/grafana/deployment.dashboard.py
@@ -289,6 +289,7 @@ dashboard = Dashboard(
                             'available{deployment=\"$deployment_name\",'
                             'namespace=\"$deployment_namespace\"}) without '
                             '(instance, pod)',
+                            'instant': true,
                         },
                     ],
                     rangeMaps=[


### PR DESCRIPTION
Set the default 'instant' value set to 'true' for 'Avaliable Replicas' board.
Without this, the value shown will be the average according to the time range selected. Something like "Avaliable Replicas: 1.2", that does not make much sense for this metric.